### PR TITLE
fix: replace deprecated method

### DIFF
--- a/enhanced-rich-text-editor-demo/pom.xml
+++ b/enhanced-rich-text-editor-demo/pom.xml
@@ -9,7 +9,7 @@
 
     <name>Enhanced Rich Text Editor Demo</name>
 
-    <version>2.4.4</version>
+    <version>2.4.5</version>
 
     <inceptionYear>2019</inceptionYear>
     <organization>
@@ -73,7 +73,7 @@
         <dependency>
             <groupId>com.vaadin.componentfactory</groupId>
             <artifactId>enhanced-rich-text-editor</artifactId>
-            <version>2.4.4</version>
+            <version>${project.version}</version>
         </dependency>
 
     </dependencies>
@@ -95,7 +95,7 @@
             <plugin>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-maven-plugin</artifactId>
-                <version>9.4.11.v20180605</version>
+                <version>${jetty.plugin.version}</version>
                 <configuration>
                     <scanIntervalSeconds>1</scanIntervalSeconds>
                 </configuration>

--- a/enhanced-rich-text-editor/pom.xml
+++ b/enhanced-rich-text-editor/pom.xml
@@ -9,7 +9,7 @@
 
     <name>Enhanced Rich Text Editor</name>
 
-    <version>2.4.4</version>
+    <version>2.4.5</version>
     <inceptionYear>2019</inceptionYear>
     <organization>
         <name>Vaadin Ltd</name>

--- a/enhanced-rich-text-editor/src/main/java/com/vaadin/componentfactory/GeneratedEnhancedRichTextEditor.java
+++ b/enhanced-rich-text-editor/src/main/java/com/vaadin/componentfactory/GeneratedEnhancedRichTextEditor.java
@@ -271,10 +271,11 @@ public abstract class GeneratedEnhancedRichTextEditor<R extends GeneratedEnhance
         List<TabStop> tabStops = new ArrayList<>();
         JsonArray rawArray = (JsonArray) getElement()
                 .getPropertyRaw("tabStops");
-        getElement().synchronizeProperty("tabStops", "tabStops-changed");
-        getElement().synchronizeProperty("tabStops", "tab-stops-changed");
-        getElement().synchronizeProperty("tabStops", "change");
-        getElement().synchronizeProperty("tabStops", "value-changed");
+                 
+        getElement().addPropertyChangeListener("tabStops", "tabStops-changed", e -> {});
+        getElement().addPropertyChangeListener("tabStops", "tab-stops-changed", e -> {});
+        getElement().addPropertyChangeListener("tabStops", "change", e -> {});
+        getElement().addPropertyChangeListener("tabStops", "value-changed", e -> {});
 
         if (rawArray == null) {
             return tabStops;

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <groupId>com.vaadin.componentfactory</groupId>
     <artifactId>enhanced-rich-text-editor-root</artifactId>
     <packaging>pom</packaging>
-    <version>2.4.4</version>
+    <version>2.4.5</version>
     <name>EnhancedRich Text Editor Root</name>
     <inceptionYear>2018</inceptionYear>
 


### PR DESCRIPTION
Replace deprecated method to avoid compatibility issue when using the component in a Vaadin 23 application.