### PR TITLE
Replace alignment/indent/lock icons

### DIFF
--- a/enhanced-rich-text-editor-demo/pom.xml
+++ b/enhanced-rich-text-editor-demo/pom.xml
@@ -9,7 +9,7 @@
 
     <name>Enhanced Rich Text Editor Demo</name>
 
-    <version>2.5.0</version>
+    <version>2.5.1</version>
 
     <inceptionYear>2019</inceptionYear>
     <organization>

--- a/enhanced-rich-text-editor/pom.xml
+++ b/enhanced-rich-text-editor/pom.xml
@@ -9,7 +9,7 @@
 
     <name>Enhanced Rich Text Editor</name>
 
-    <version>2.5.0</version>
+    <version>2.5.1</version>
     <inceptionYear>2019</inceptionYear>
     <organization>
         <name>Vaadin Ltd</name>

--- a/enhanced-rich-text-editor/src/main/java/com/vaadin/componentfactory/GeneratedEnhancedRichTextEditor.java
+++ b/enhanced-rich-text-editor/src/main/java/com/vaadin/componentfactory/GeneratedEnhancedRichTextEditor.java
@@ -220,7 +220,7 @@ import elemental.json.impl.JreJsonObject;
         "WebComponent: Vaadin.RichTextEditorElement#1.0.0-alpha3",
         "Flow#1.2-SNAPSHOT" })
 @Tag("vcf-enhanced-rich-text-editor")
-@NpmPackage(value = "@vaadin-component-factory/vcf-enhanced-rich-text-editor", version = "1.5.0")
+@NpmPackage(value = "@vaadin-component-factory/vcf-enhanced-rich-text-editor", version = "1.5.1")
 @JsModule("@vaadin-component-factory/vcf-enhanced-rich-text-editor/src/vcf-enhanced-rich-text-editor.js")
 public abstract class GeneratedEnhancedRichTextEditor<R extends GeneratedEnhancedRichTextEditor<R, T>, T>
         extends AbstractSinglePropertyField<R, T> implements HasStyle, HasTheme,

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <groupId>com.vaadin.componentfactory</groupId>
     <artifactId>enhanced-rich-text-editor-root</artifactId>
     <packaging>pom</packaging>
-    <version>2.5.0</version>
+    <version>2.5.1</version>
     <name>EnhancedRich Text Editor Root</name>
     <inceptionYear>2018</inceptionYear>
 


### PR DESCRIPTION
Update web component version to 1.5.1, to include replacement of icons for alignment, indent and readonly options.