### PR TITLE
Slotted icons

### DIFF
--- a/enhanced-rich-text-editor-demo/pom.xml
+++ b/enhanced-rich-text-editor-demo/pom.xml
@@ -9,7 +9,7 @@
 
     <name>Enhanced Rich Text Editor Demo</name>
 
-    <version>3.0.1</version>
+    <version>4.0.0</version>
 
     <inceptionYear>2019</inceptionYear>
     <organization>

--- a/enhanced-rich-text-editor-demo/src/main/java/com/vaadin/componentfactory/EnhancedRichTextEditorView.java
+++ b/enhanced-rich-text-editor-demo/src/main/java/com/vaadin/componentfactory/EnhancedRichTextEditorView.java
@@ -6,6 +6,7 @@ import com.vaadin.flow.component.Key;
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.button.ButtonVariant;
 import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.icon.Icon;
 import com.vaadin.flow.component.icon.VaadinIcon;
 import com.vaadin.flow.component.notification.Notification;
 import com.vaadin.flow.component.textfield.TextArea;
@@ -33,6 +34,7 @@ public class EnhancedRichTextEditorView extends DemoView {
         createEditorWithPlaceholders();
         createEditorWithCustomButtons();
         createEditorWithCustomShortcutsForStandardButtons();
+        createEditorWithIconReplacementForStandardButtons();
     }
 
     private void createDefaultEditor() {
@@ -67,6 +69,33 @@ public class EnhancedRichTextEditorView extends DemoView {
       addCard("Basic Rich Text Editor with custom shortcuts for standard buttons", rte);
     }
 
+    private void createEditorWithIconReplacementForStandardButtons() {
+        // begin-source-example
+        // source-example-heading: Basic Rich Text Editor with icon replacement for standard buttons
+        EnhancedRichTextEditor rte = new EnhancedRichTextEditor();
+        
+        // replace undo button icon
+        Icon newUndoIcon = new Icon(VaadinIcon.ARROW_BACKWARD);
+        newUndoIcon.setColor("grey");
+        newUndoIcon.setSize("1.25em");
+        rte.replaceStandardToolbarButtonIcon(ToolbarButton.UNDO, newUndoIcon);
+        
+        // replace redo button icon
+        Icon newRedoIcon = new Icon(VaadinIcon.ARROW_FORWARD);
+        newRedoIcon.setColor("grey");
+        newRedoIcon.setSize("1.25em");
+        rte.replaceStandardToolbarButtonIcon(ToolbarButton.REDO, newRedoIcon);
+        
+        // replace redo button icon
+        Icon imageIcon = new Icon(VaadinIcon.PICTURE);
+        imageIcon.setSize("1.25em");
+        rte.replaceStandardToolbarButtonIcon(ToolbarButton.IMAGE, imageIcon);
+                
+        // end-source-example
+        addCard("Basic Rich Text Editor with icon replacement for standard buttons", rte);
+      }
+    
+    
     private void createEditorWithCustomButtons() {
         // begin-source-example
         // source-example-heading: Rich Text Editor With Custom Buttons

--- a/enhanced-rich-text-editor/pom.xml
+++ b/enhanced-rich-text-editor/pom.xml
@@ -9,7 +9,7 @@
 
     <name>Enhanced Rich Text Editor</name>
 
-    <version>3.0.1</version>
+    <version>4.0.0</version>
     <inceptionYear>2019</inceptionYear>
     <organization>
         <name>Vaadin Ltd</name>

--- a/enhanced-rich-text-editor/src/main/java/com/vaadin/componentfactory/EnhancedRichTextEditor.java
+++ b/enhanced-rich-text-editor/src/main/java/com/vaadin/componentfactory/EnhancedRichTextEditor.java
@@ -35,6 +35,7 @@ import com.vaadin.flow.component.UI;
 import com.vaadin.flow.component.button.Button;
 import com.vaadin.flow.component.dependency.JavaScript;
 import com.vaadin.flow.component.dependency.JsModule;
+import com.vaadin.flow.component.icon.Icon;
 import com.vaadin.flow.data.binder.Binder;
 import com.vaadin.flow.data.value.HasValueChangeMode;
 import com.vaadin.flow.data.value.ValueChangeMode;
@@ -440,6 +441,17 @@ public class EnhancedRichTextEditor
         Boolean altKey) {
       getElement().executeJs("$0.addToolbarFocusBinding($1, $2, $3, $4)", getElement(), keyCode,
           shortKey, shiftKey, altKey);
+    }
+    
+    /**
+     * Allows to replace the icon of a standard {@link ToolbarButton toolbar button}.
+     * 
+     * @param toolbarButton toolbar button to replace icon
+     * @param icon replacement icon
+     */
+    public void replaceStandardToolbarButtonIcon(ToolbarButton toolbarButton, Icon icon) {
+   	 	Objects.requireNonNull(icon, "Icon can't be null");
+        SlotUtil.replaceStandardButtonIcon(this, icon, toolbarButton.getButtonName());
     }
     
     /**

--- a/enhanced-rich-text-editor/src/main/java/com/vaadin/componentfactory/GeneratedEnhancedRichTextEditor.java
+++ b/enhanced-rich-text-editor/src/main/java/com/vaadin/componentfactory/GeneratedEnhancedRichTextEditor.java
@@ -220,7 +220,7 @@ import elemental.json.impl.JreJsonObject;
         "WebComponent: Vaadin.RichTextEditorElement#1.0.0-alpha3",
         "Flow#1.2-SNAPSHOT" })
 @Tag("vcf-enhanced-rich-text-editor")
-@NpmPackage(value = "@vaadin-component-factory/vcf-enhanced-rich-text-editor", version = "2.0.1")
+@NpmPackage(value = "@vaadin-component-factory/vcf-enhanced-rich-text-editor", version = "3.0.0")
 @JsModule("@vaadin-component-factory/vcf-enhanced-rich-text-editor/src/vcf-enhanced-rich-text-editor.js")
 public abstract class GeneratedEnhancedRichTextEditor<R extends GeneratedEnhancedRichTextEditor<R, T>, T>
         extends AbstractSinglePropertyField<R, T> implements HasStyle, HasTheme,

--- a/enhanced-rich-text-editor/src/main/java/com/vaadin/componentfactory/SlotUtil.java
+++ b/enhanced-rich-text-editor/src/main/java/com/vaadin/componentfactory/SlotUtil.java
@@ -4,9 +4,9 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.HasElement;
 import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.icon.Icon;
 import com.vaadin.flow.dom.Element;
 
 public class SlotUtil {
@@ -66,4 +66,12 @@ public class SlotUtil {
             return null;
         }
     }
+    
+	public static void replaceStandardButtonIcon(EnhancedRichTextEditor target, Icon icon, String iconSlotName) {
+		if (icon != null) {
+			clearSlot(target, iconSlotName);
+			icon.getElement().setAttribute("slot", iconSlotName);
+			target.getElement().appendChild(icon.getElement());
+		}
+	}
 }

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <groupId>com.vaadin.componentfactory</groupId>
     <artifactId>enhanced-rich-text-editor-root</artifactId>
     <packaging>pom</packaging>
-    <version>3.0.1</version>
+    <version>4.0.0</version>
     <name>EnhancedRich Text Editor Root</name>
     <inceptionYear>2018</inceptionYear>
 


### PR DESCRIPTION
This PR includes:

* update of web-component version to 3.0.0 to get new features:
     - fix to arrow keys navigation: was not working when navigation reached hidden buttons
     - make each toolbar standard button to include a slot for the icon, so icons can be replaced easily if wanted with a new Icon.
* new API for Icon replacement
* new demo example on Icon replacement

Version has been upgraded to 4.0.0 as changes in web-component are considered breaking as they include styling changes that might affect styling applied to buttons.
