### PR TITLE
fix: incorrect placeholder formatting

### DIFF
--- a/enhanced-rich-text-editor/src/main/resources/META-INF/resources/frontend/src/vcf-enhanced-rich-text-editor-blots.js
+++ b/enhanced-rich-text-editor/src/main/resources/META-INF/resources/frontend/src/vcf-enhanced-rich-text-editor-blots.js
@@ -299,10 +299,19 @@ class PlaceholderBlot extends Embed {
     let altText = '';
     let text = placeholder.text;
     if (PlaceholderBlot.altAppearanceRegex) {
-      altText = new RegExp(PlaceholderBlot.altAppearanceRegex).exec(text) || '';
-      const altTextNodeStr = `<span alt>${altText}</span>`;
-      if (altText && placeholder.altAppearance) text = altTextNodeStr;
-      else text = text.replace(altText, altTextNodeStr);
+      const match = new RegExp(PlaceholderBlot.altAppearanceRegex).exec(text);
+      if(match) {
+        altText = match[0];
+        const altTextNodeStr = `<span alt>${altText}</span>`;
+        const startIndex = match.index;
+        const endIndex = startIndex + altText.length;
+        if(placeholder.altAppearance) text = altTextNodeStr;
+        else text = text.slice(0,startIndex) + altTextNodeStr + text.slice(endIndex);
+      } else {
+        if(placeholder.altAppearance) {
+          text = '';
+        }
+      }
     }
     if (PlaceholderBlot.tags && !placeholder.altAppearance) text = PlaceholderBlot._wrapTags(text);
     node.innerHTML = text;


### PR DESCRIPTION
If the value of the placeholder appears in the key of the placeholder, the corresponding part of the key receives the formatting of the value. This change uses the matching index to replace the correct location.

Fixes #40